### PR TITLE
measure_battery + battery types on TRADFRI things

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This app for [Athom Homey](https://homey.app/en-us/) adds support for [deCONZ](https://www.dresden-elektronik.de/funk/software/deconz.html)'s [[RaspBee](https://www.phoscon.de/en/raspbee)/[ConBee](https://www.phoscon.de/en/conbee)] child devices.
 
-[![current version](https://img.shields.io/badge/version-0.10.0-<COLOR>.svg)](https://shields.io/)
+[![current version](https://img.shields.io/badge/version-0.10.1-<COLOR>.svg)](https://shields.io/)
 
 List of supported devices for current version:
 

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "id": "ru.notabene.deconz",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "compatibility": ">=1.5.0",
   "sdk": 2,
   "name": {

--- a/app.json
+++ b/app.json
@@ -25,6 +25,9 @@
     "developers": [
       {
         "name": "Skorpion"
+      },
+      {
+        "name": "k4mrat"
       }
     ]
   },
@@ -59,7 +62,10 @@
         "en": "Tradfri Square Dimmer"
       },
       "class": "other",
-      "capabilities": [],
+      "capabilities": ["measure_battery"],
+      "energy": {
+        "batteries": [ "CR2032" ] 
+      },
       "images": {
         "large": "/drivers/hue-warm-white/assets/images/large.png",
         "small": "/drivers/hue-warm-white/assets/images/small.png"
@@ -84,7 +90,10 @@
         "en": "Tradfri Remote Control"
       },
       "class": "other",
-      "capabilities": [],
+      "capabilities": ["measure_battery"],
+      "energy": {
+        "batteries": [ "CR2032" ] 
+      },
       "images": {
         "large": "/drivers/hue-warm-white/assets/images/large.png",
         "small": "/drivers/hue-warm-white/assets/images/small.png"
@@ -398,7 +407,8 @@
       "class": "sensor",
       "capabilities": [
         "alarm_motion",
-        "dark"
+        "dark",
+        "measure_battery"
       ],
       "images": {
         "large": "/drivers/mi-motion/assets/images/large.png",
@@ -419,7 +429,7 @@
       ],
       "energy": {
         "batteries": [
-          "CR2032"
+          "CR2032", "CR2032"
         ]
       },
       "settings": [


### PR DESCRIPTION
added measure_battery on TRADFRI things as well as battery types. (will need repairing to work)
Corrected amount of batteries in TMS.

Issue:
All devices report batttery eventually so Homey can read it, except TMS. Waited 24 hours and still a grey battery... It does show battery status in Phoscon and Node Red, so might just need more waiting.